### PR TITLE
[TITAN-389] - Product Page: Sale items show current price as crossed out price.

### DIFF
--- a/components/ProductCard/ProductCard.js
+++ b/components/ProductCard/ProductCard.js
@@ -38,7 +38,7 @@ const ProductCard = ({ product }) => {
           <span>
             {product?.variants?.nodes[0]?.compareAtPrice ? (
               <>
-                <del data-testid="sale-price">
+                <del data-testid="compare-price">
                   {priceFormatter(
                     product?.variants?.nodes[0]?.compareAtPrice?.amount,
                     product?.variants?.nodes[0]?.compareAtPrice?.currencyCode

--- a/components/ProductCard/__tests__/ProductCard.test.js
+++ b/components/ProductCard/__tests__/ProductCard.test.js
@@ -51,8 +51,9 @@ describe('<ProductCard />', () => {
 
     expect(screen.getByText('$18.00')).toBeVisible();
     expect(screen.getByText('Radiowave Shirt')).toBeVisible();
+    expect(screen.getByText('$20.00')).toBeVisible();
     expect(screen.getByTestId('product-img')).toBeVisible();
     expect(screen.getByText('Sale')).toBeVisible();
-    expect(screen.getByTestId('sale-price')).toBeVisible();
+    expect(screen.getByTestId('compare-price')).toBeVisible();
   });
 });

--- a/components/ProductDetails/ProductDetails.js
+++ b/components/ProductDetails/ProductDetails.js
@@ -82,9 +82,7 @@ const ProductDetails = ({ product }) => {
   return (
     <div>
       {productNotification && (
-        <ProductNotification
-          productNotification={productNotification}
-        />
+        <ProductNotification productNotification={productNotification} />
       )}
       <div className={styles.component}>
         <div className={styles.detailsColumn}>
@@ -101,7 +99,7 @@ const ProductDetails = ({ product }) => {
           )}
           <h1>{product?.title}</h1>
           <ProductPrice
-            salePrice={selectedVariant?.compareAtPrice}
+            compareAtPrice={selectedVariant?.compareAtPrice?.amount}
             price={selectedVariant?.price?.amount}
             currencyCode={selectedVariant?.price?.currencyCode}
           />

--- a/components/ProductDetails/ProductPrice.js
+++ b/components/ProductDetails/ProductPrice.js
@@ -4,24 +4,22 @@ import priceFormatter from '../../utilities/priceFormatter';
  * Render the ProductPrice component.
  *
  * @param {Props} props The props object.
- * @param {string | number} props.salePrice The sale price for this product, if available.
- * @param {string | number} props.price The price for this product.
+ * @param {string | number} props.compareAtPrice The original price for this product, if on sale.
+ * @param {string | number} props.price The current price for this product.
  * @param {string | number} props.currencyCode The currency code for this product's price.
  *
  * @returns {React.ReactElement} The ProductPrice component.
  */
 
-const ProductPrice = ({ salePrice, price, currencyCode }) => {
+const ProductPrice = ({ compareAtPrice, price, currencyCode }) => {
   return (
     <p className="price">
-      {salePrice !== null ? (
+      {compareAtPrice && (
         <>
-          <del>{priceFormatter(price, currencyCode)}</del>{' '}
-          {priceFormatter(salePrice?.amount, salePrice?.currencyCode)}
+          <del>{priceFormatter(compareAtPrice, currencyCode)}</del>{' '}
         </>
-      ) : (
-        <>{priceFormatter(price, currencyCode)}</>
       )}
+      {priceFormatter(price, currencyCode)}
     </p>
   );
 };

--- a/components/ProductDetails/ProductPrice.js
+++ b/components/ProductDetails/ProductPrice.js
@@ -15,9 +15,9 @@ const ProductPrice = ({ compareAtPrice, price, currencyCode }) => {
   return (
     <p className="price">
       {compareAtPrice && (
-        <>
+        <span data-testid="compare-price">
           <del>{priceFormatter(compareAtPrice, currencyCode)}</del>{' '}
-        </>
+        </span>
       )}
       {priceFormatter(price, currencyCode)}
     </p>

--- a/components/ProductDetails/__tests__/ProductDetails.test.js
+++ b/components/ProductDetails/__tests__/ProductDetails.test.js
@@ -36,6 +36,26 @@ describe('<ProductDetails />', () => {
     expect(screen.getByText(/Triangulum Hoodie/i)).toBeInTheDocument();
   });
 
+  it('displays a product with compare at price crossed out', () => {
+    const variantsProduct = productsStub.data.products.nodes[0];
+    render(<ProductDetails product={variantsProduct} />);
+
+    expect(screen.getByText(/Radiowave Shirt/i)).toBeInTheDocument();
+    expect(screen.getByTestId('compare-price')).toBeInTheDocument();
+    expect(screen.getByText('$20.00')).toBeVisible();
+    expect(screen.getByText('$18.00')).toBeVisible();
+  });
+
+  it('displays a product with only one current price', () => {
+    const variantsProduct = productsStub.data.products.nodes[1];
+    render(<ProductDetails product={variantsProduct} />);
+
+    expect(screen.getByText(/Quark Shirt/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('compare-price')).not.toBeInTheDocument();
+    expect(screen.getByText('$20.00')).toBeVisible();
+    expect(screen.queryByText('$18.00')).not.toBeInTheDocument();
+  });
+
   it('changes the image and the colour at the same time', () => {
     const variantsProduct = productsStub.data.products.nodes[3];
     render(<ProductDetails product={variantsProduct} />);
@@ -159,8 +179,10 @@ describe('<ProductDetails />', () => {
     );
 
     await waitFor(() => {
-      expect((screen.getByRole('button')).dataset.cartId).toBe("gid://shopify/Cart/c1-74d26c3130aa39e303d99d4d430c6eca");
-    })
+      expect(screen.getByRole('button').dataset.cartId).toBe(
+        'gid://shopify/Cart/c1-74d26c3130aa39e303d99d4d430c6eca'
+      );
+    });
 
     act(() => {
       fireEvent.click(screen.getByText(/Add to cart/i).closest('button'));

--- a/utilities/__tests__/priceFormatter.test.js
+++ b/utilities/__tests__/priceFormatter.test.js
@@ -6,24 +6,34 @@ describe('priceFormatter', () => {
 
     expect(price).toBe('$3.00');
   });
+
   it('formats a single decimal price to double digit', () => {
     const price = priceFormatter('3.5');
 
     expect(price).toBe('$3.50');
   });
+
   it('formats a double decimal price to double digit', () => {
     const price = priceFormatter('3.56');
 
     expect(price).toBe('$3.56');
   });
+
   it('formats an empty price to double digit zero', () => {
     const price = priceFormatter('');
 
     expect(price).toBe('$0.00');
   });
+
   it('formats a missing price to double digit zero', () => {
     const price = priceFormatter();
 
     expect(price).toBe('$0.00');
+  });
+
+  it('formats a price with a currency code other than USD', () => {
+    const price = priceFormatter('3.56', 'EUR');
+
+    expect(price).toBe('€3.56');
   });
 });


### PR DESCRIPTION
## Description

This PR uses the terminology `compareAtPrice` on the product details page when passed as a prop to the `ProductPrice` component rather than `salePrice`. `compareAtPrice` is now being crossed out and the price being rendered as normal, in line with the product cards. 

JIRA: [TITAN-389](https://wpengine.atlassian.net/jira/software/c/projects/TITAN/boards/1122?modal=detail&selectedIssue=TITAN-389)

## Testing

- Confirmed that the same crossed out price is appearing on the product details page as is shown in the card when listed on homepage and shop page. 
- Confirmed that for pages without a price nothing is crossed out and current price still shown. 
- Confirmed that the cart contains the same price wether on sale or the current price. 
- Confirmed all tests still pass


[TITAN-389]: https://wpengine.atlassian.net/browse/TITAN-389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ