### PR TITLE
fix: update href to docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a starter Blueprint to get you up and running quickly o
 
 - [Check out the demo store here](https://atlasshopify.wpengine.com)
 - [Try a sandbox version of Atlas to get started with this Blueprint](https://wpengine.com/headless-wordpress/)
-- [Documentation can be found here](#)
+- [Documentation can be found here](https://developers.wpengine.com/docs/atlas-shopify-blueprint/introduction)
 
 ## Development
 


### PR DESCRIPTION
## Description

URL needed to be added after docs were published at https://developers.wpengine.com/docs/atlas-shopify-blueprint/introduction 
