### PR TITLE
[TITAN-380] - feat(Cart): :sparkles: Added maxAge of 8 days to the Cart cookie

### DIFF
--- a/constants/carts.js
+++ b/constants/carts.js
@@ -1,1 +1,2 @@
 export const CART_COOKIE = 'atlas-shopify-cart';
+export const EIGHT_DAYS_IN_SECONDS = (60 * 60 * 24 * 8);

--- a/hooks/useShopifyCart.js
+++ b/hooks/useShopifyCart.js
@@ -6,7 +6,7 @@ import RETRIEVE_CART from '../queries/Cart';
 import ADD_TO_CART from '../mutations/AddToCart';
 import REMOVE_FROM_CART from '../mutations/RemoveFromCart';
 import UPDATE_CART_QUANTITY from '../mutations/QuantityCart';
-import { CART_COOKIE } from '../constants/carts';
+import { CART_COOKIE, EIGHT_DAYS_IN_SECONDS } from '../constants/carts';
 
 /**
  * Render the ShopifyCartProvider component.
@@ -49,7 +49,7 @@ export function ShopifyCartProvider({ children }) {
         variables: { input: {} },
       })
         .then((response) => {
-          cookies.set(CART_COOKIE, response.data.cartCreate.cart.id);
+          cookies.set(CART_COOKIE, response.data.cartCreate.cart.id, { maxAge: EIGHT_DAYS_IN_SECONDS });
           setCartData(response.data.cartCreate.cart);
         })
         .catch((err) => console.error(err));


### PR DESCRIPTION
## Description

<!--
Include a summary of the change and some contextual information.
-->

This PR adds add the `maxAge` option when creating the cart cookie, setting it to eight days.

<!--
Provide a link to the JIRA ticket (if any) for issue tracking purposes
-->

https://wpengine.atlassian.net/browse/TITAN-380

<!--
Remember to notify CX of any changes before you merge
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

- No automated tests were included since the `maxAge` option is implemented by the `universal-cookie` package
- Manual testing instructions:
  - Make sure you don't have a stale cart cookie: delete the `atlas-shopify-cart` cookie
  - Navigate to a product details page
  - Click "Add to cart"
  - Open the development tools and verify the expiration date of the `atlas-shopify-cart` cookie
## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation and updated wiki pages.
-->

## Dependent PRs

<!--
List any dependent PR's that are awaiting review. And in order to have these dependencies listed as part of the checks section, use the following syntax:

Depends on #1234
-->
