### PR TITLE
Update version to 1.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@faustwp/atlas-shopify-blueprint",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@faustwp/atlas-shopify-blueprint",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "dependencies": {
         "@apollo/client": "^3.11.8",
         "@apollo/react-testing": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@faustwp/atlas-shopify-blueprint",
   "private": true,
-  "version": "1.0.7",
+  "version": "1.0.8",
   "scripts": {
     "dev": "faust dev",
     "build": "faust build",


### PR DESCRIPTION
Includes dependencies updates and rebranding of Atlas to Headless Platform.