### PR TITLE
Ignoring both major and patch dependencies versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,6 @@ updates:
       interval: 'weekly'
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-patch"


### PR DESCRIPTION
We don't want major versions to avoid breaking changes, while the patch versions are too often and don't usually bring much features

## Description

<!--
Include a summary of the change and some contextual information.
-->

This PR adds FEATURE. We decided to implement FEATURE using THIS METHOD instead of THAT METHOD because of REASONS.

<!--
Provide a link to the JIRA ticket (if any) for issue tracking purposes
-->

https://wpengine.atlassian.net/browse/

<!--
Remember to notify CX of any changes before you merge
-->

## Testing

<!--
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Also list any relevant details for your test configuration such as how to test the changes locally or in staging.
-->

- Included/Didn't include unit tests. Execute the test suite using `npm run test` and all tests should pass.
- Manual testing instructions:

  - Step 1
  - Step 2
  - Step 3
  - Expected result

## Screenshots

<!--
If this is a visual change include relevant screenshots about the behavior of the application before and after this change.
-->

## Documentation Changes

<!--
List corresponding changes to the documentation and updated wiki pages.
-->

## Dependent PRs

<!--
List any dependent PR's that are awaiting review. And in order to have these dependencies listed as part of the checks section, use the following syntax:

Depends on #1234
-->
